### PR TITLE
Add two command aliases that were on @Pyrobolser's bot

### DIFF
--- a/bot/grenouille_irc_bot.py
+++ b/bot/grenouille_irc_bot.py
@@ -41,6 +41,10 @@ class GrenouilleIrcBot(irc.bot.SingleServerIRCBot):
             'youtube': self.youtube,
             'twitter': self.twitter
         }
+        self.aliases = {
+            't': 'twitter',
+            'y': 'youtube'
+        }
 
         irc.bot.SingleServerIRCBot.__init__(self, [(server, port, password)], nickname, nickname)
         self.channel = channel
@@ -92,13 +96,16 @@ class GrenouilleIrcBot(irc.bot.SingleServerIRCBot):
             return
         else:
             split = message[1:].split(' ', 1)
-            if split[0] not in self.commands:
-                return
-            else:
-                answer = self.commands[split[0]](is_admin, split[1] if len(split) > 1 else None)
 
-                for line in answer or []:
-                    connection.privmsg(self.channel, line)
+            if split[0] in self.commands:
+                answer = self.commands[split[0]](is_admin, split[1] if len(split) > 1 else None)
+            elif split[0] in self.aliases and self.aliases[split[0]] in self.commands:
+                answer = self.commands[self.aliases[split[0]]](is_admin, split[1] if len(split) > 1 else None)
+            else:
+                return
+
+            for line in answer or []:
+                connection.privmsg(self.channel, line)
 
     ######################################
     # Methods linked to the bot commands #
@@ -160,7 +167,7 @@ class GrenouilleIrcBot(irc.bot.SingleServerIRCBot):
         if is_admin and parameters is not None:
             self.who_data = 'Streamers actuels: {0}'.format(parameters)
         return [self.who_data]
-    
+
     def youtube(self, is_admin=False, parameters=None):
         """Print the youtube official channel of the FroggedTV
 


### PR DESCRIPTION
I've seen people trying to use `!t <name>` command without success. That was sad, so this is now fixed.